### PR TITLE
Add support of forks and authorization token

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,30 @@ Triggered when GDCore wants to print a message.
 ##### `error`:
 Triggered when GDCore errors.
 
-#### `loadGD(version?: string): Promise<WrappedGD>`
+##### `loadGD(version?: string | {`
+##### &nbsp;&nbsp; `versionTag?: string,`
+##### &nbsp;&nbsp; `user?: string,`
+##### &nbsp;&nbsp; `authToken?: string,`
+##### &nbsp;&nbsp; `fetchProvider?: {`
+##### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `libGDPath: string`
+##### &nbsp;&nbsp;&nbsp;&nbsp; `} | {`
+##### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `useReleaseAssets: true } |`
+##### &nbsp;&nbsp;&nbsp;&nbsp; `} | {`
+##### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `"libGD.js": (gdPath: string) => Promise<void>,`
+##### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `"libGD.wasm"?: (gdPath: string) => Promise<void>,`
+##### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `"libGD.js.mem"?: (gdPath: string) => Promise<void>,`
+##### &nbsp;&nbsp;&nbsp;&nbsp; `}`
+##### &nbsp;&nbsp; `}`
+##### `}): Promise<WrappedGD>`
 
-The entrypoint of the module. Accept a github release tag to specify a specific version to download and use.
+The entrypoint of the module. Accept a github release tag to specify a specific version to download and use or configuration object where:
+- versionTag - optional github release tag
+- user - optional github GDevelop project or fork owner.
+- authToken - optional github private token for github API authorization 
+- fetchProvider - optional configuration for libGD assets loading. You can provide next settings:
+  - libGDPath - url to libGD assets
+  - useReleaseAssets - defines to load assets from release attachments
+  - libGD.js, libGD.wasm, libGD.js.mem - function providers to rely on for appropriate files loading
 
 #### `WrappedGD.gd: gd`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gdcore-tools",
-  "version": "1.0.5",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gdcore-tools",
-      "version": "1.0.5",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^5.4.12",

--- a/src/WrappedGD.js
+++ b/src/WrappedGD.js
@@ -8,7 +8,8 @@ const {
 } = require("./EventsFunctionsExtensionsLoader/LocalEventsFunctionCodeWriter");
 const saveProject = require("./LocalProjectWriter");
 const assignIn = require("lodash/assignIn");
-const { getGD, getRuntimePath } = require("./downloadGD");
+const getGD = require("./getGD");
+const { getRuntimePath } = require("./fsUtils");
 const { join, resolve } = require("path");
 const { makeFS } = require("./LocalFileSystem");
 

--- a/src/WrappedGD.js
+++ b/src/WrappedGD.js
@@ -43,7 +43,7 @@ class WrappedGD extends EventEmitter {
      * The path to the current version.
      * @private
      */
-    this.versionPath = getRuntimePath(fetchOptions.version, fetchOptions.user);
+    this.versionPath = getRuntimePath(fetchOptions.versionTag, fetchOptions.user);
 
     // Begin async loading of GDCore and extensions
     getGD(fetchOptions, {

--- a/src/WrappedGD.js
+++ b/src/WrappedGD.js
@@ -13,7 +13,7 @@ const { join, resolve } = require("path");
 const { makeFS } = require("./LocalFileSystem");
 
 class WrappedGD extends EventEmitter {
-  constructor(version) {
+  constructor(fetchOptions) {
     super();
 
     /**
@@ -43,10 +43,10 @@ class WrappedGD extends EventEmitter {
      * The path to the current version.
      * @private
      */
-    this.versionPath = getRuntimePath(version);
+    this.versionPath = getRuntimePath(fetchOptions.version, fetchOptions.user);
 
     // Begin async loading of GDCore and extensions
-    getGD(version, {
+    getGD(fetchOptions, {
       print: (message) => this.emit("print", message),
       printErr: (e) => this.emit("error", e),
       onAbort: (e) => this.emit("error", e),

--- a/src/downloadGD.js
+++ b/src/downloadGD.js
@@ -32,7 +32,7 @@ const libGdAssets = {
  *    useReleaseAssets: true
  *  }
  * } GdFetchDataProvider
- * Fetch configuration that provides methods or url to load libGD assets.
+ * Fetch configuration that provides methods or URL to load libGD assets.
  */
 
 /**
@@ -67,7 +67,7 @@ const getFetchConfiguration = async (options) => {
 };
 
 /**
- * Downloads a GDevelop Runtime sources and compile them.
+ * Downloads GDevelop Runtime sources and compiles them.
  * 
  * @param {{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }} fetchConfiguration Fetch configuration.
  * @param {string} gdPath Path to save Runtime sources folder to.
@@ -103,7 +103,7 @@ const downloadLibGdAssets = async function ({ versionTag, user, fetchProvider, a
 
     assert(
       libGdAssets.required.every((libGdAsset) => assetsIdsMap[libGdAsset]),
-      `❌ Your release do not provide all required libGd assets: ${libGdAssets.required}. Provided: ${Object.values(assetsIdsMap)}.`
+      `❌ Your release does not provide all required libGd assets: ${libGdAssets.required}. Provided: ${Object.values(assetsIdsMap)}.`
     );
 
     return Promise.all(

--- a/src/downloadGD.js
+++ b/src/downloadGD.js
@@ -1,120 +1,36 @@
 const fs = require("fs-extra-promise");
 const path = require("path");
-const { request } = require("@octokit/request");
-const { https } = require("follow-redirects");
 const assert = require("assert");
+const { getLatestCiCommit, getAssetsIdsMap, downloadGitBinaryAsset } = require("./gitUtils");
+const { findLatestVersion, getRuntimePath, downloadFile, extractGdRuntimes } = require("./fsUtils");
 
 const gdAuthor = "4ian";
-const libGdAssets = [
-  "libGD.js",
-  "libGD.wasm",
-  "libGD.js.mem",
-];
-const isRequiredLibGdAssets = (libGdAssets) => libGdAssets === "libGD.js";
-
-const getVersionsPath = () => path.join(__dirname, "Versions");
-const getUserPath = (user) => path.join(getVersionsPath(), user);
-const getRuntimePath = (version, user) => path.join(getUserPath(user), version);
-
-const getAuthHeader = (authToken) => authToken ? { authorization: authToken } : { };
-
-const downloadFile = (file, savePath, required = true) =>
-  new Promise((resolve) => {
-    https.get(file, function (response) {
-      if (response.statusCode !== 200) {
-        if (required)
-          throw new Error(
-            `❌ Cannot download ${file}! Error ${response.statusCode}: ${response.statusMessage}`
-          );
-        // Silently fail if the file is not required
-        else return resolve(true);
-      }
-      response.pipe(fs.createWriteStream(savePath)).addListener("close", () => {
-        resolve();
-      });
-    });
-  });
-
-const findLatestVersion = (user, authToken) =>
-  new Promise((resolve, reject) => {
-    // Fetch base release infos
-    console.info(`🕗 Getting latest release tag...`);
-    return request(`GET /repos/${user}/GDevelop/releases/latest`, {
-        headers: getAuthHeader(authToken)
-      })
-      .then(({ data }) => {
-        resolve(data.tag_name);
-      })
-      .catch(() => {
-        console.error("❌ Couldn't fetch latest version, using latest local version.");
-        fs.readdirAsync(getUserPath(user))
-          .then((versions) => resolve(versions[0]))
-          .catch(() => {
-            console.error("💀 Fatal Error! Couldn't find or download the latest version.");
-            reject();
-          });
-      });
-  });
-
-const extractGdZip = async (
-  zipPath,
-  savePath,
-  prefixUser,
-  pathsToExtract,
-  pathMapper = (pathToMap) => pathToMap
-) => {
-  const StreamZip = require("node-stream-zip");
-  const zip = new StreamZip.async({
-    file: zipPath,
-    storeEntries: true,
-  });
-  const getDir = (pathToFile) => path.extname(pathToFile) ? path.dirname(pathToFile) : pathToFile;
-  const prefix = `${prefixUser}-GDevelop-${(await zip.comment).slice(0, 7)}`;
-
-  try {
-    for (const relatedPathToExtract of pathsToExtract) {
-      const pathToExtract = savePath + "/" + getDir(pathMapper(relatedPathToExtract));
-
-      await fs.ensureDir(pathToExtract);
-      await zip.extract(prefix + "/" + relatedPathToExtract, pathToExtract);
-    }
-    await zip.close();
-  } catch (err) {
-    console.error("❌ Error while extracting the GDevelop archive! ", e);
+const libGdAssets = {
+  required: [
+    "libGD.js"
+  ],
+  optional: [
+    "libGD.wasm",
+    "libGD.js.mem",
+  ],
+  getAll() {
+    return this.required.concat(this.optional);
+  },
+  isRequired(assetName) {
+    return this.required.includes(assetName);
   }
-}
-
-const getLatestCiCommit = async (versionTag, authToken) => {
-  const headers = getAuthHeader(authToken);
-  let { data: commit } =
-    await request("GET /repos/4ian/GDevelop/commits/{ref}", {
-      ref: (
-        await request("GET /repos/4ian/GDevelop/git/ref/tags/{tag}", {
-          tag: versionTag,
-        })
-      ).data.object.sha,
-      headers,
-    });
-
-  // Go up to the latest commit for which libGD.js was built
-  while (commit.commit.message.indexOf("[skip ci]") !== -1) {
-    commit = (
-      await request("GET /repos/4ian/GDevelop/commits/{ref}", {
-        ref: commit.parents[0].sha,
-        headers,
-      })
-    ).data;
-  }
-
-  return commit;
-}
+};
 
 /**
  * @typedef {{
  *    'libGD.js': (string) => Promise<void>,
  *    'libGD.wasm'?: (string) => Promise<void>,
  *    'libGD.js.mem'?: (string) => Promise<void>
- *  } | { libGDPath: string }
+ *  } | {
+ *    libGDPath: string
+ *  } | {
+ *    useReleaseAssets: true
+ *  }
  * } GdFetchDataProvider
  * Fetch configuration that provides methods or url to load libGD assets.
  */
@@ -123,7 +39,7 @@ const getLatestCiCommit = async (versionTag, authToken) => {
  * Verifies and complements passed fetch configuration object.
  * 
  * @param {{ versionTag?: string, user?: string, fetchProvider?: GdFetchDataProvider, authToken?: string } | string} options Fetch configuration to complete.
- * @returns {{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }} Complete fetch configuration object.
+ * @returns {Promise<{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }>} Complete fetch configuration object.
  */
 const getFetchConfiguration = async (options) => {
   if (typeof options === "string") options = { versionTag: options }
@@ -140,11 +56,10 @@ const getFetchConfiguration = async (options) => {
   } else {
     assert(options.fetchProvider, "❌ You should pass fetchProvider instance if fork is used.");
     assert(
-      libGdAssets.every((libGdAsset) =>
-        !isRequiredLibGdAssets(libGdAsset) ||
-        typeof options.fetchProvider[libGdAsset] === "function"
-      ) || options.fetchProvider.libGDPath, 
-      `❌ You should provide fetch methods or fetch url for necessary libGD assets: ${libGdAssets.map(isRequiredLibGdAssets)}.`
+      libGdAssets.required.every((libGdAsset) => typeof options.fetchProvider[libGdAsset] === "function") ||
+      options.fetchProvider.libGDPath ||
+      options.fetchProvider.useReleaseAssets,
+      `❌ You should provide fetch methods or fetch url for necessary libGD assets: ${libGdAssets.required}.`
     );
   }
 
@@ -152,108 +67,102 @@ const getFetchConfiguration = async (options) => {
 };
 
 /**
- * Downloads a GDevelop version (libGD.js, the runtime and the extensions).
+ * Downloads a GDevelop Runtime sources and compile them.
  * 
  * @param {{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }} fetchConfiguration Fetch configuration.
+ * @param {string} gdPath Path to save Runtime sources folder to.
  */
-const downloadVersion = async function ({ versionTag, user, fetchProvider }) {
-  const tasks = [];
-  const gdPath = getRuntimePath(versionTag, user);
-
-  // Make sure "Versions" directory exists
-  fs.ensureDirSync(getVersionsPath());
-  // Clear directory
-  fs.emptyDirSync(gdPath);
-
-  // Fetch the file with GDJS Runtime and extensions
+const downloadGdRuntimes = async ({ versionTag, user }, gdPath) => {
+  const zipPath = path.join(gdPath, "gd.zip");
+  
   console.info(`🕗 Starting download of GDevelop Runtime '${versionTag}'...`);
-  tasks.push(
-    (async () => {
-      const zipPath = path.join(gdPath, "gd.zip");
-      const pathMapping = {
-        "GDJS/Runtime": "Runtime",
-        "Extensions": "Runtime/Extensions",
-      };
-      await downloadFile(`https://codeload.github.com/${user}/GDevelop/legacy.zip/${versionTag}`, zipPath);
-      console.info(`✅ Done downloading GDevelop Runtime '${versionTag}'`);
-      console.info(`🕗 Extracting GDevelop Runtime '${versionTag}'...`);
-      await extractGdZip(
-        zipPath,
-        gdPath,
-        user,
-        ['GDJS/Runtime', "Extensions"],
-        (pathToMap) => pathMapping[pathToMap] || pathToMap,
-      );
-      await fs.remove(zipPath);
-      console.info(`✅ Done extracting the GDevelop Runtime`)
-    })()
-    .then(() => {
-      if (!fs.existsSync(path.join(gdPath, "Runtime/gd.js"))) {
-        console.info(`🕗 Compiling Runtime...`);
-        return require("./build")(gdPath);
-      }
-    }
-  ));
+  await downloadFile(`https://codeload.github.com/${user}/GDevelop/legacy.zip/${versionTag}`, zipPath);
+  console.info(`✅ Done downloading GDevelop Runtime '${versionTag}'`);
+  console.info(`🕗 Extracting GDevelop Runtime '${versionTag}'...`);
+  await extractGdRuntimes(zipPath, gdPath, user);
+  await fs.remove(zipPath);
+  console.info(`✅ Done extracting the GDevelop Runtime`);
 
-  console.info(`🕗 Starting download of GDevelop Core...`);
-  for (const libGdAsset of libGdAssets) {
-    const isRequired = isRequiredLibGdAssets(libGdAsset);
-
-    if (fetchProvider[libGdAsset]) {
-      console.info(`🕗 Delegate loading of '${libGdAsset}' to available provider...`);
-      tasks.push(
-        fetchProvider[libGdAsset](gdPath)
-        .then(() => console.info(`✅ Loading of '${libGdAsset}' is finished by provider.`))
-      );
-    } else if (fetchProvider.libGDPath) {
-      tasks.push(
-        downloadFile(fetchProvider.libGDPath + libGdAsset, path.join(gdPath, libGdAsset), isRequired)
-        .then((errored) => !errored && console.info(`✅ Done downloading ${libGdAsset}`))
-      );
-    } else if (!isRequired) {
-      console.warn(`Skip loading of '${libGdAsset}' as fetching data is not provided.`)
-    } else {
-      throw new Error(`❌ No fetching data provided for required asset '${libGdAsset}'.`)
-    }
+  if (!fs.existsSync(path.join(gdPath, "Runtime/gd.js"))) {
+    console.info(`🕗 Compiling Runtime...`);
+    return require("./build")(gdPath);
   }
-
-  await Promise.all(tasks);
-  console.info(`✅ Successfully downloaded GDevelop version '${versionTag}'`);
-};
+}
 
 /**
- * Initialize libGD.js.
- * If the version is not present, download it.
- * Returning `gd` doesn't work, so a hacky workaround with global is used.
+ * Downloads a GDevelop version libGD assets.
+ * 
  * @param {{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }} fetchOptions Fetch configuration.
+ * @param {string} gdPath Path to save libGd assets to.
  */
- const getGD = async function (fetchOptions, gdOptions) {
-  const runtimePath = getRuntimePath(fetchOptions.versionTag, fetchOptions.user);
-  // Download the version if it isn't present
-  if (!fs.existsSync(runtimePath)) {
-    console.log("❌ The GDevelop versionTag was not found, downloading it!");
-    
-    try {
-      await downloadVersion(fetchOptions);
-    } catch (err) {
-      fs.rmSync(runtimePath, { recursive: true });
-      throw err;
-    }
+const downloadLibGdAssets = async function ({ versionTag, user, fetchProvider, authToken }, gdPath) {
+  console.info(`🕗 Starting download of GDevelop Core...`);
+  if (fetchProvider.useReleaseAssets) {
+    console.info(`🕗 Using ${versionTag} release assets...`);
+    const assetsIdsMap = await getAssetsIdsMap(user, versionTag, authToken);
+
+    assert(
+      libGdAssets.required.every((libGdAsset) => assetsIdsMap[libGdAsset]),
+      `❌ Your release do not provide all required libGd assets: ${libGdAssets.required}. Provided: ${Object.values(assetsIdsMap)}.`
+    );
+
+    return Promise.all(
+      libGdAssets
+        .getAll()
+        .filter((libGdAsset) => assetsIdsMap[libGdAsset])
+        .map(async (libGdAsset) => {
+          await downloadGitBinaryAsset(path.join(gdPath, libGdAsset), user, assetsIdsMap[libGdAsset], authToken);
+          console.info(`✅ Done downloading ${libGdAsset}`);
+        })
+    );
   }
 
-  const gd = require(path.join(runtimePath, "libGD.js"))(gdOptions);
-  return new Promise((resolve) => {
-    gd.then(() => {
-      // Make sure gd is not thenable as the promise would think it is one as well.
-      delete gd.then;
-      resolve(gd);
-    });
-  });
+  if (fetchProvider.libGDPath) {
+    console.info(`🕗 Using ${fetchProvider.libGDPath} url...`);
+    return Promise.all(
+      libGdAssets
+        .getAll()
+        .map((libGdAsset) => (
+          downloadFile(fetchProvider.libGDPath + libGdAsset, path.join(gdPath, libGdAsset), libGdAssets.isRequired(libGdAsset))
+            .then((errored) => !errored && console.info(`✅ Done downloading ${libGdAsset}`))
+        ))
+    );
+  }
+  console.info(`🕗 Using provider functions...`);
+  return Promise.all(
+    libGdAssets
+      .getAll()
+      .filter((libGdAsset) => fetchProvider[libGdAsset])
+      .map(async (libGdAsset) => {
+        await fetchProvider[libGdAsset](gdPath);
+        console.info(`✅ Loading of '${libGdAsset}' is finished by provider.`);
+      })
+  );
+}
+
+/**
+ * Downloads a GDevelop version (libGD.js, the runtime and the extensions).
+ * 
+ * @param {{ versionTag: string, user: string, fetchProvider: GdFetchDataProvider, authToken?: string }} fetchOptions Fetch configuration.
+ */
+const downloadVersion = function (fetchOptions) {
+  const {
+    versionTag,
+    user
+  } = fetchOptions;
+  const gdPath = getRuntimePath(versionTag, user);
+
+  fs.emptyDirSync(gdPath);
+
+  return Promise.all([
+    downloadGdRuntimes(fetchOptions, gdPath),
+    downloadLibGdAssets(fetchOptions, gdPath),
+  ]).then(() =>
+    console.info(`✅ Successfully downloaded GDevelop version '${versionTag}'`)
+  );
 };
 
 module.exports = {
-  getRuntimePath,
-  getGD,
-  findLatestVersion,
   getFetchConfiguration,
+  downloadVersion,
 };

--- a/src/fsUtils.js
+++ b/src/fsUtils.js
@@ -5,22 +5,22 @@ const StreamZip = require("node-stream-zip");
 const { findLatestRelease } = require("./gitUtils");
 
 /**
- * @param {string} user User to get path to versions of.
+ * @param {string} user User to get the path to versions of.
  * @returns {string} Path to specific user Gdevelop versions folder. 
  */
 const getUserPath = (user) => path.join(__dirname, "Versions", user);
 
 /**
  * @param {string} version Version to get path to.
- * @param {string} user User to get path to version of.
+ * @param {string} user User to get the path to the version of.
  * @returns {string} Path to specific Gdevelop version folder. 
  */
 const getRuntimePath = (version, user) => path.join(getUserPath(user), version);
 
 /**
- * @param {string} user User to get latest Gdevelop version of.
- * @param {string} [authToken] Github private token for autorization. 
- * @returns {Promise<string>} Promisified latest available version for specified user.
+ * @param {string} user User to get the latest Gdevelop version of.
+ * @param {string} [authToken] Github private token for authorization. 
+ * @returns {Promise<string>} Promisified latest available version for the specified user.
  */
 const findLatestVersion = async (user, authToken) => {
   console.info(`🕗 Getting latest release tag...`);
@@ -40,7 +40,7 @@ const findLatestVersion = async (user, authToken) => {
 
 /**
  * @param {string} file File url to download.
- * @param {string} savePath Path to save downloaded file.
+ * @param {string} savePath Path to save the downloaded file.
  * @param {boolean} required Defines if need to throw if loading error occurs. Throw if true is passed.
  */
 const downloadFile = (file, savePath, required = true) =>
@@ -60,10 +60,10 @@ const downloadFile = (file, savePath, required = true) =>
 const getDir = (pathToFile) => path.extname(pathToFile) ? path.dirname(pathToFile) : pathToFile;
 
 /**
- * Extracts Runtime sources from GDevelop github release archive.
+ * Extracts Runtime sources from GDevelop GitHub release archive.
  * @param {string} zipPath Path to Gdevelop zip archive.
  * @param {string} savePath Path to save extracted Runtime sources folder to.
- * @param {string} prefixUser Github user of GDevelop github release archive.
+ * @param {string} prefixUser Github user of GDevelop GitHub release archive.
  */
 const extractGdRuntimes = async (zipPath, savePath, prefixUser) => {
   const zip = new StreamZip.async({

--- a/src/fsUtils.js
+++ b/src/fsUtils.js
@@ -1,0 +1,99 @@
+const fs = require("fs-extra-promise");
+const https = require("https");
+const path = require("path");
+const StreamZip = require("node-stream-zip");
+const { findLatestRelease } = require("./gitUtils");
+
+/**
+ * @param {string} user User to get path to versions of.
+ * @returns {string} Path to specific user Gdevelop versions folder. 
+ */
+const getUserPath = (user) => path.join(__dirname, "Versions", user);
+
+/**
+ * @param {string} version Version to get path to.
+ * @param {string} user User to get path to version of.
+ * @returns {string} Path to specific Gdevelop version folder. 
+ */
+const getRuntimePath = (version, user) => path.join(getUserPath(user), version);
+
+/**
+ * @param {string} user User to get latest Gdevelop version of.
+ * @param {string} [authToken] Github private token for autorization. 
+ * @returns {Promise<string>} Promisified latest available version for specified user.
+ */
+const findLatestVersion = async (user, authToken) => {
+  console.info(`🕗 Getting latest release tag...`);
+  return (
+    findLatestRelease(user, authToken)
+      .catch(() => {
+        console.error("❌ Couldn't fetch latest version, using latest local version.");
+        fs.readdirAsync(getUserPath(user))
+          .then((versions) => resolve(versions[0]))
+          .catch(() => {
+            console.error("💀 Fatal Error! Couldn't find or download the latest version.");
+            reject();
+          });
+      })
+  )
+}
+
+/**
+ * @param {string} file File url to download.
+ * @param {string} savePath Path to save downloaded file.
+ * @param {boolean} required Defines if need to throw if loading error occurs. Throw if true is passed.
+ */
+const downloadFile = (file, savePath, required = true) =>
+  new Promise((resolve) => {
+    https.get(file, function (response) {
+      if (response.statusCode !== 200) {
+        if (required) throw new Error(`❌ Cannot download ${file}! Error ${response.statusCode}: ${response.statusMessage}`);
+        // Silently fail if the file is not required
+        else return resolve(true);
+      }
+      response.pipe(fs.createWriteStream(savePath)).addListener("close", () => {
+        resolve();
+      });
+    });
+  });
+
+const getDir = (pathToFile) => path.extname(pathToFile) ? path.dirname(pathToFile) : pathToFile;
+
+/**
+ * Extracts Runtime sources from GDevelop github release archive.
+ * @param {string} zipPath Path to Gdevelop zip archive.
+ * @param {string} savePath Path to save extracted Runtime sources folder to.
+ * @param {string} prefixUser Github user of GDevelop github release archive.
+ */
+const extractGdRuntimes = async (zipPath, savePath, prefixUser) => {
+  const zip = new StreamZip.async({
+    file: zipPath,
+    storeEntries: true,
+  });
+  const prefix = `${prefixUser}-GDevelop-${(await zip.comment).slice(0, 7)}`;
+  const runtimesPaths = {
+    "GDJS/Runtime": "Runtime",
+    "Extensions": "Runtime/Extensions",
+  };
+
+  try {
+    for (const relatedPathToExtract in runtimesPaths) {
+      const saveDir = savePath + "/" + getDir(runtimesPaths[relatedPathToExtract]);
+
+      await fs.ensureDir(saveDir);
+      await zip.extract(prefix + "/" + relatedPathToExtract, saveDir);
+    }
+    await zip.close();
+  } catch (err) {
+    console.error("❌ Error while extracting the GDevelop archive! ", e);
+  }
+}
+
+
+module.exports = {
+  getUserPath,
+  getRuntimePath,
+  downloadFile,
+  extractGdRuntimes,
+  findLatestVersion,
+};

--- a/src/getGD.js
+++ b/src/getGD.js
@@ -1,0 +1,34 @@
+const fs = require("fs-extra-promise");
+const path = require("path");
+const { getRuntimePath } = require("./fsUtils");
+const { downloadVersion } = require("./downloadGD");
+
+/**
+ * Initialize libGD.js.
+ * If the version is not present, download it.
+ * Returning `gd` doesn't work, so a hacky workaround with global is used.
+ * @param {{ versionTag: string, user: string, fetchProvider: import("./downloadGD").GdFetchDataProvider, authToken?: string }} fetchOptions Fetch configuration.
+ */
+module.exports = async function (fetchOptions, gdOptions) {
+  const runtimePath = getRuntimePath(fetchOptions.versionTag, fetchOptions.user);
+  // Download the version if it isn't present
+  if (!fs.existsSync(runtimePath)) {
+    console.log("❌ The GDevelop versionTag was not found, downloading it!");
+
+    try {
+      await downloadVersion(fetchOptions);
+    } catch (err) {
+      fs.rmSync(runtimePath, { recursive: true });
+      throw err;
+    }
+  }
+
+  const gd = require(path.join(runtimePath, "libGD.js"))(gdOptions);
+  return new Promise((resolve) => {
+    gd.then(() => {
+      // Make sure gd is not thenable as the promise would think it is one as well.
+      delete gd.then;
+      resolve(gd);
+    });
+  });
+};

--- a/src/gitUtils.js
+++ b/src/gitUtils.js
@@ -2,17 +2,17 @@ const { request } = require("@octokit/request");
 const fs = require("fs-extra-promise");
 
 /**
- * Returns octokit request authorization object if token is provided.
- * @param {string} [authToken] Github private token for autorization.
+ * Returns octokit request authorization object if the token is provided.
+ * @param {string} [authToken] Github private token for authorization.
  * @returns {{ authorization: string } | { }} Octokit request authorization object.
  */
 const getAuthHeader = (authToken) => authToken ? { authorization: authToken } : {};
 
 /**
- * Returns map object of release asset names as keys and assets ids as values.
+ * Returns map object of release asset names as keys and asset ids as values.
  * @param {string} user Github user of release.
  * @param {string} versionTag Release tag to get assets of.
- * @param {string} [authToken] Github private token for autorization. 
+ * @param {string} [authToken] Github private token for authorization. 
  * @returns {Promise<{ [assetName: string]: string }>} Map object of asset names to ids.
  */
 const getAssetsIdsMap = async (user, versionTag, authToken) => {
@@ -28,11 +28,11 @@ const getAssetsIdsMap = async (user, versionTag, authToken) => {
 };
 
 /**
- * Downloads github release asset.
+ * Downloads GitHub release asset.
  * @param {string} filePath Path to save asset by.
  * @param {string} user Github user of release asset.
  * @param {string} id Specific release asset id.
- * @param {string} [authToken] Github private token for autorization. 
+ * @param {string} [authToken] Github private token for authorization. 
  * @returns {Promise<void>}
  */
 const downloadGitBinaryAsset = (filePath, user, id, authToken) =>
@@ -47,9 +47,9 @@ const downloadGitBinaryAsset = (filePath, user, id, authToken) =>
     .then(({ data }) => fs.writeFile(filePath, Buffer.from(data)));
 
 /**
- * Returns latest commit for which libGD.js was built for official GDevelop repo.
+ * Returns the latest commit for which libGD.js was built for the official GDevelop repo.
  * @param {string} versionTag Release tag to get assets of.
- * @param {string} [authToken] Github private token for autorization. 
+ * @param {string} [authToken] Github private token for authorization. 
  * @returns {Object} Octokit commit object.
  */
 const getLatestCiCommit = async (versionTag, authToken) => {
@@ -78,9 +78,9 @@ const getLatestCiCommit = async (versionTag, authToken) => {
 }
 
 /**
- * Returns latest GDevelop repo release for specified user.
+ * Returns the latest GDevelop repo release for the specified user.
  * @param {string} user Github user of release.
- * @param {string} [authToken] Github private token for autorization. 
+ * @param {string} [authToken] Github private token for authorization. 
  * @returns {Promise<string>} Latest GDevelop repo release for specified user
  */
 const findLatestRelease = (user, authToken) =>

--- a/src/gitUtils.js
+++ b/src/gitUtils.js
@@ -1,0 +1,100 @@
+const { request } = require("@octokit/request");
+const fs = require("fs-extra-promise");
+
+/**
+ * Returns octokit request authorization object if token is provided.
+ * @param {string} [authToken] Github private token for autorization.
+ * @returns {{ authorization: string } | { }} Octokit request authorization object.
+ */
+const getAuthHeader = (authToken) => authToken ? { authorization: authToken } : {};
+
+/**
+ * Returns map object of release asset names as keys and assets ids as values.
+ * @param {string} user Github user of release.
+ * @param {string} versionTag Release tag to get assets of.
+ * @param {string} [authToken] Github private token for autorization. 
+ * @returns {Promise<{ [assetName: string]: string }>} Map object of asset names to ids.
+ */
+const getAssetsIdsMap = async (user, versionTag, authToken) => {
+  const {
+    data: { assets }
+  } = await request('GET /repos/{user}/GDevelop/releases/tags/{tag}', {
+    user,
+    tag: versionTag,
+    headers: getAuthHeader(authToken),
+  });
+
+  return assets.reduce((data, { id, name }) => (data[name] = id) && data, {});
+};
+
+/**
+ * Downloads github release asset.
+ * @param {string} filePath Path to save asset by.
+ * @param {string} user Github user of release asset.
+ * @param {string} id Specific release asset id.
+ * @param {string} [authToken] Github private token for autorization. 
+ * @returns {Promise<void>}
+ */
+const downloadGitBinaryAsset = (filePath, user, id, authToken) =>
+  request('GET /repos/{user}/GDevelop/releases/assets/{id}', {
+    user,
+    id,
+    headers: {
+      ...getAuthHeader(authToken),
+      accept: 'application/octet-stream',
+    },
+  })
+    .then(({ data }) => fs.writeFile(filePath, Buffer.from(data)));
+
+/**
+ * Returns latest commit for which libGD.js was built for official GDevelop repo.
+ * @param {string} versionTag Release tag to get assets of.
+ * @param {string} [authToken] Github private token for autorization. 
+ * @returns {Object} Octokit commit object.
+ */
+const getLatestCiCommit = async (versionTag, authToken) => {
+  const headers = getAuthHeader(authToken);
+  let { data: commit } =
+    await request("GET /repos/4ian/GDevelop/commits/{ref}", {
+      ref: (
+        await request("GET /repos/4ian/GDevelop/git/ref/tags/{tag}", {
+          tag: versionTag,
+        })
+      ).data.object.sha,
+      headers,
+    });
+
+  // Go up to the latest commit for which libGD.js was built
+  while (commit.commit.message.indexOf("[skip ci]") !== -1) {
+    commit = (
+      await request("GET /repos/4ian/GDevelop/commits/{ref}", {
+        ref: commit.parents[0].sha,
+        headers,
+      })
+    ).data;
+  }
+
+  return commit;
+}
+
+/**
+ * Returns latest GDevelop repo release for specified user.
+ * @param {string} user Github user of release.
+ * @param {string} [authToken] Github private token for autorization. 
+ * @returns {Promise<string>} Latest GDevelop repo release for specified user
+ */
+const findLatestRelease = (user, authToken) =>
+  request(`GET /repos/${user}/GDevelop/releases/latest`, {
+    headers: getAuthHeader(authToken)
+  })
+  .then(({ data }) => {
+    resolve(data.tag_name);
+  })
+
+module.exports = {
+  getAssetsIdsMap,
+  getAuthHeader,
+  downloadGitBinaryAsset,
+  getLatestCiCommit,
+  findLatestRelease,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
-const { findLatestVersion } = require("./downloadGD");
+const { getFetchConfiguration } = require("./downloadGD");
 const WrappedGD = require("./WrappedGD");
 
-const loadGD = async (version) => {
-  if (version === undefined) version = await findLatestVersion();
+/**
+ * @param {{ version?: string, user?: string, fetchProvider?: GdFetchDataProvider, authToken?: string } | string} [options] Optional fetch configuration or github release tag.
+ */
+const loadGD = async (loadOptions) => {  
+  fetchOptions = await getFetchConfiguration(loadOptions || {});
+
   return new Promise((resolve, reject) => {
-    const wgd = new WrappedGD(version);
+    const wgd = new WrappedGD(fetchOptions);
     wgd.once("ready", () => {
       wgd.removeAllListeners();
       resolve(wgd);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ const { getFetchConfiguration } = require("./downloadGD");
 const WrappedGD = require("./WrappedGD");
 
 /**
- * @param {{ versionTag?: string, user?: string, fetchProvider?: GdFetchDataProvider, authToken?: string } | string} [options] Optional fetch configuration or github release tag.
+ * @param {{ versionTag?: string, user?: string, fetchProvider?: import("./downloadGD").GdFetchDataProvider, authToken?: string } | string} [options]
+ * Optional fetch configuration or github release tag.
  */
 const loadGD = async (loadOptions) => {  
   fetchOptions = await getFetchConfiguration(loadOptions || {});

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const WrappedGD = require("./WrappedGD");
 
 /**
  * @param {{ versionTag?: string, user?: string, fetchProvider?: import("./downloadGD").GdFetchDataProvider, authToken?: string } | string} [options]
- * Optional fetch configuration or github release tag.
+ * Optional fetch configuration or GitHub release tag.
  */
 const loadGD = async (loadOptions) => {  
   fetchOptions = await getFetchConfiguration(loadOptions || {});

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { getFetchConfiguration } = require("./downloadGD");
 const WrappedGD = require("./WrappedGD");
 
 /**
- * @param {{ version?: string, user?: string, fetchProvider?: GdFetchDataProvider, authToken?: string } | string} [options] Optional fetch configuration or github release tag.
+ * @param {{ versionTag?: string, user?: string, fetchProvider?: GdFetchDataProvider, authToken?: string } | string} [options] Optional fetch configuration or github release tag.
  */
 const loadGD = async (loadOptions) => {  
   fetchOptions = await getFetchConfiguration(loadOptions || {});

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,15 @@ const { getFetchConfiguration } = require("./downloadGD");
 const WrappedGD = require("./WrappedGD");
 
 /**
- * @param {{ versionTag?: string, user?: string, fetchProvider?: import("./downloadGD").GdFetchDataProvider, authToken?: string } | string} [options]
- * Optional fetch configuration or GitHub release tag.
+ * @typedef {{ versionTag?: string, user?: string, fetchProvider?: import("./downloadGD").GdFetchDataProvider, authToken?: string }} LoadGDOptions
+ * @property {string} [versionTag] The version of GDevelop to load.
+ * @property {string} [user] The GitHub user of GDevelop project.
+ * @property {string} [authToken] The GitHub token for GitHub API authorization.
+ * @property {import("./downloadGD").GdFetchDataProvider} [fetchProvider] The fetch options.
+ */
+
+/**
+ * @param {LoadGDOptions | string} [loadOptions] Optional loading configuration or GitHub release tag.
  */
 const loadGD = async (loadOptions) => {  
   fetchOptions = await getFetchConfiguration(loadOptions || {});


### PR DESCRIPTION
Hi and sorry that I barge in like this)

For the last few months I have been actively working with GDevelop and its improvement and I found your tool very convenient.

This PR adds two main features
- authorization token support for `octokit request api` to increase API limit rate
```
loadGD({
    authToken: "your private github token",
})
```
- support of loading GDevelop sources from forks
I added `user` option to redirect to forks. Loading of `Runtime` sources is pretty easy task in this case but storage of `libGD` assets is a more specific thing. E.g. in my case I attach them to release. I added few options to improve flexibility 
```
// helps in my case. simply check assets attached to `versionTag` release
loadGD({
    user: "f0nar",
    versionTag: "pixi-spine-commitment",
    fetchProvider: {
      useReleaseAssets: true,
    },
});

// case if you publish assets to some storage
loadGD({
    user: "f0nar",
    versionTag: "pixi-spine-commitment",
    fetchProvider: {
      libGDPath: `https://some/url/to/published/libGD/assets`
    },
});


// case if you need more complicated functionality to load these assets
loadGD({
    user: "f0nar",
    versionTag: "pixi-spine-commitment",
    fetchProvider: {
      'libGD.js': (gdPath) => downloadAsset(gdPath, 'libGD.js'),
      'libGD.wasm': (gdPath) => downloadAsset(gdPath, 'libGD.wasm'),
    },
});
```

I want to say that I did not break old API structure
```
// It is still possible to pass release tag only
loadGD("v5.3.158");
// or nothing at all
loadGD();
```

P.S. During my changes code grew so much so I allowed myself to split it by different files. Hope that is ok)

Here is exporter PR https://github.com/arthuro555/gdexporter/pull/9